### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,26 @@
 version: 2.1
 
-workflows:
-  main:
-    jobs:
-      - build:
-          context: cimg-publishing
+orbs:
+  cimg: circleci/cimg@0.3.3
 
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2022.06
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "20.10.14"
-      - run:
-          name: "Build Docker Images"
-          command: |
-            ./build-images.sh
-            echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
-      - deploy:
-          name: "Publish Docker Images (main branch only)"
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              
-              # an else block will be added in the future for a staging release
-              if git log -1 --pretty=%s | grep "\[release\]"; then
-                echo "Publishing cimg/azure to Docker Hub production."
-                ./push-images.sh
-              else
-                echo "Skipping publishing."
-              fi
-            fi
+workflows:
+  main-wf:
+    jobs:
+      - cimg/build-and-deploy:
+          name: "Staging"
+          docker-namespace: ccitest
+          docker-repository: azure
+          publish-branch: test
+          filters:
+            branches:
+              ignore:
+                - main
+          context: cimg-publishing
+      - cimg/build-and-deploy:
+          name: "Deploy"
+          docker-repository: azure
+          filters:
+            branches:
+              only:
+                - main
+          context: cimg-publishing 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,8 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 
 # Install Azure related tools
 RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null && \
-	echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list && \
+	[[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64" && \
+	echo "deb [arch=${ARCH}] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list && \
 	sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 		apt-transport-https \
 		azure-cli \

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=azure
 parent=deploy
 variants=()
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Add arm64 support with buildx multi arch builds

# Reasons

Enables arm64 support using the updating tooling in cimg-shared and cimg-orb and arch checks for the software included in this image

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-azure/39/workflows/c8ae1cf6-bea1-467c-875c-85ad0600ad83/jobs/41

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
