### PR TITLE
feat: add check feed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,23 @@ version: 2.1
 
 orbs:
   cimg: circleci/cimg@0.3.3
+  gh: circleci/github-cli@2.2.0
+
+parameters:
+  trigger:
+    type: boolean
+    default: false
 
 workflows:
+  automated-wf:
+    when: << pipeline.parameters.trigger >>
+    jobs:
+      - check-feed:
+          context:
+            - cimg-publishing
   main-wf:
+    when:
+      not: << pipeline.parameters.trigger >>
     jobs:
       - cimg/build-and-deploy:
           name: "Staging"
@@ -23,4 +37,48 @@ workflows:
             branches:
               only:
                 - main
-          context: cimg-publishing 
+          context: cimg-publishing
+
+jobs:
+  check-feed:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "f8:07:0f:f6:b5:eb:57:ae:be:4d:2f:2d:be:70:8f:ff"
+      - run:
+          name: SSH config to pull and push project
+          command: |
+            ssh-add -D
+            ssh-add ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff
+            ssh-keygen -f ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff -y > ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff.pub
+            echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch secops+cpe-image-bot@circleci.com" > ~/.ssh/allowed_signers
+      - run:
+          name: Run git config
+          command: |
+            cat \<<'EOF' >> ~/githelper.sh
+              #!/usr/bin/env bash
+              echo username=$GIT_USERNAME
+              echo password=$IMAGE_BOT_TOKEN
+            EOF
+
+            git config --global user.email "secops+cpe-image-bot@circleci.com"
+            git config --global user.name "cpe-image-bot"
+            git config --global user.signingkey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch"
+            git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+            git config --global url."https://github.com".insteadOf ssh://git@github.com
+            git config --global url."https://github.com/".insteadOf git@github.com:
+            git config --global credential.helper "/bin/bash ~/githelper.sh"
+            git config --global gpg.format ssh
+            git config --global commit.gpgsign true
+            git submodule sync
+      - gh/setup:
+          token: IMAGE_BOT_TOKEN
+      - run:
+          name: Run version update script
+          command: |
+            sudo chmod +x azureFeed.sh
+            git submodule update --init --recursive
+            ./azureFeed.sh

--- a/azureFeed.sh
+++ b/azureFeed.sh
@@ -13,7 +13,7 @@ interval="monthly"
 function azureFeed() {
   replaceDatedTags "$templateFile" "$interval"
   if docker buildx imagetools inspect "$namespace/$parent:$RELEASE-node" &> /dev/null; then
-    [[ -n $STRING_TO_REPLACE || -n $RELEASEMONTHLY ]] && ./shared/release "$RELEASEMONTHLY"
+    [[ -n $STRING_TO_REPLACE || -n $RELEASEMONTHLY ]] && ./shared/release "$RELEASEMONTHLY" || exit 0
   else
     echo "cimg/deploy:$RELEASE-node does not exist"
     exit 0


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
adds check feed to automate pipeline. check is [here](https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-azure/53/workflows/e2f67519-4890-4b51-b7e8-4db82bb9b39c)
